### PR TITLE
Moves FC list into a dict. Saves dict to env file. Adds del_FC and rename_FC commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ Fleet Carrier owners would allow the bot to do this in a similar manner that the
 
 Once the rework is released, we hope to finally do away with inaccurate FC location data, inaccurate market data, etc. Until then, we excitedly wait!
 
+## First time setup
+Create a `.env` file with the following values:
+
+```
+DISCORD_TOKEN=YOUR_TOKEN_HERE
+DISCORD_GUILD=SERVER_NAME_HERE
+```
+
+The tracked fleet carriers will be written to this file, so ensure it has write permissions for the bot user.
+
 ## Features, Commands, How-Tos
 The EDStockTracker uses ';' as a prefix for commands. Example: ;ping
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ DISCORD_GUILD=SERVER_NAME_HERE
 
 The tracked fleet carriers will be written to this file, so ensure it has write permissions for the bot user.
 
+# Required Permissions and Intents
+
+The bot requires the following server permissions to function: (Permission Integer: 103079308352)
+- Send Messages
+- Public Threads
+- Private Threads
+- Manage Messages
+- Embed Links
+- Read Message History
+- Add Reactions
+- View Channels
+
+As well, it requires the following intents:
+- Presence Intent
+- Server Members Intent
+
 ## Features, Commands, How-Tos
 The EDStockTracker uses ';' as a prefix for commands. Example: ;ping
 

--- a/bot.py
+++ b/bot.py
@@ -226,6 +226,8 @@ async def fclist(ctx):
     names = names.strip('\n')
     namelist = names.split('.')
     namelist.remove('')
+    if not namelist:
+        namelist = ['No Fleet Carriers are being tracked, add one!']
     print('Listing active carriers')
     namelist = '\n'.join(namelist)  # Joining the list with newline as the delimeter
     embed = discord.Embed(title='Tracked carriers')
@@ -249,5 +251,20 @@ async def on_command_error(ctx, error):
     if isinstance(error, commands.errors.CheckFailure):
         await ctx.send('You do not have the correct role for this command.')
 
-bot.run(TOKEN)
 
+def verify_config():
+    # if this is the first run with a fresh .env, format it the way we expect.
+    fcfile = open(".env")
+    envlist = fcfile.readlines()
+    fcfile.close()
+    if len(envlist) < 6:
+        print(f'.env Fleet Carrier list is empty, making space.')
+        envlist += ['\n'] * (6 - len(envlist))
+        fcfile = open(".env", "w")
+        fcwrite = "".join(envlist)
+        fcfile.write(fcwrite)
+        fcfile.close()
+
+
+verify_config()
+bot.run(TOKEN)

--- a/bot.py
+++ b/bot.py
@@ -13,12 +13,14 @@ import os
 import discord
 import re
 import requests
-from dotenv import load_dotenv
+import json
+from dotenv import find_dotenv, load_dotenv, set_key
 from discord.ext import commands
 
 load_dotenv()
 TOKEN = os.getenv('DISCORD_TOKEN')
 GUILD = os.getenv('DISCORD_GUILD')
+CARRIERS = os.getenv('FLEET_CARRIERS')
 intents = discord.Intents.default()
 intents.members = True
 
@@ -63,24 +65,22 @@ async def dingle(ctx):
                                  '\n!!SYSTEMS WITH SPACES IN THE NAMES NEED TO BE "QUOTED LIKE THIS"!! ')
 @commands.has_any_role('Carrier Owner','Bot Handler')
 async def addFC(ctx, FCCode, FCSys, FCName):
-    fcfile = open(".env")
-    envlist = fcfile.readlines()
-    fcfile.close()
-
     # Checking if FC is already in the list, and if FC name is in correct format
     # Stops if FC is already in list, or if incorrect name format
     matched = re.match("[a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9]-[a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9]", FCCode)
     isnt_match = not bool(matched)  # If it is NOT a match, we enter the Invalid FC Code condition
 
-    if FCCode in envlist[3]:
-        await ctx.send(f'{FCCode} is a code that is already in the Carrier list!')
-        return
-    elif FCName in envlist[4]:
-        await ctx.send(f'{FCName} is an alias that is already in the alias list!')
-        return
-    elif isnt_match:
+    if isnt_match:
         await ctx.send(f'Invalid Fleet Carrier Code format! Format should look like XXX-YYY')
         return
+    elif FCCode.upper() in FCDATA.keys():
+        await ctx.send(f'{FCCode} is a code that is already in the Carrier list!')
+        return
+    # iterate through our known carriers and check if the alias is already assigned.
+    for fc_code, fc_data in FCDATA.items():
+        if FCName.lower() in fc_data['FCName']:
+            await ctx.send(f'{FCName} is an alias that is already in the alias list belonging to carrier {fc_code}!')
+            return
 
     print(f'Format is good... Checking database...')
 
@@ -98,25 +98,8 @@ async def addFC(ctx, FCCode, FCSys, FCName):
     print(mid['marketId'])
     midstr = str(mid['marketId'])
 
-    envlist[3] = envlist[3].strip('\n')
-    fcput = envlist[3] + '.' + FCCode + '\n'
-    envlist[3] = fcput
-
-    envlist[4] = envlist[4].strip('\n')
-    aliasput = envlist[4] + '.' + FCName.lower() + '\n'
-    envlist[4] = aliasput
-
-    envlist[5] = envlist[5].strip('\n')
-    midput = envlist[5] + '.' + midstr + '\n'
-    envlist[5] = midput
-
-    print(envlist)
-
-    fcfile = open(".env", "w")
-    fcwrite = "".join(envlist)
-
-    fcfile.write(fcwrite)
-    fcfile.close()
+    FCDATA[FCCode.upper()] = {'FCName': FCName.lower(), 'FCMid': midstr, 'FCSys': FCSys.lower()}
+    save_carrier_data(FCDATA)
 
     await ctx.send(f'Added {FCCode} to the FC list, under reference name {FCName}')
 
@@ -158,26 +141,20 @@ async def APITest(ctx, mark):
 
 @bot.command(name='stock', help='Returns stock and location of a PTN carrier (carrier needs to be added first)')
 async def stock(ctx, fcname):
-    fcfile = open(".env")
-    envlist = fcfile.readlines()
-    fcfile.close()
-
-    names = envlist[4].lower()
-    names = names.strip('\n')
     fcname = fcname.lower()
+    fcdata = False
+    for fc_code, fc_data in FCDATA.items():
+        if fc_data['FCName'] == fcname:
+            fcdata = fc_data
+            fccode = fc_code
+            break
 
-    # this if statement is problematic... might be worth revisiting later
-    if fcname not in names:
+    if not fcdata:
         await ctx.send('The requested carrier is not in the list! Add carriers using the add_FC command!')
+        return
 
-    namelist = names.split('.')
-    envlist[5] = envlist[5].strip('\n')
-    midlist = envlist[5].split('.')
-    ind = namelist.index(fcname)
-    mid = midlist[ind]
-
-    await ctx.send(f'Fetching stock levels for {fcname}')
-    pmeters = {'marketId': mid}
+    await ctx.send(f'Fetching stock levels for {fcname} ({fccode})')
+    pmeters = {'marketId': fcdata['FCMid']}
     r = requests.get('https://www.edsm.net/api-system-v1/stations/market',params=pmeters)
     stn_data = r.json()
 
@@ -216,22 +193,57 @@ async def stock(ctx, fcname):
     print('Embed sent!')
 
 
+@bot.command(name='del_FC', help='Delete a fleet carrier from the tracking database.\n'
+                                 'FCCode: Carrier ID Code')
+@commands.has_any_role('Bot Handler')
+async def delFC(ctx, FCCode):
+    FCCode = FCCode.upper()
+    matched = re.match("[a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9]-[a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9]", FCCode)
+    isnt_match = not bool(matched)  # If it is NOT a match, we enter the Invalid FC Code condition
+
+    if isnt_match:
+        await ctx.send(f'Invalid Fleet Carrier Code format! Format should look like XXX-YYY')
+        return
+    if FCCode in FCDATA.keys():
+        fcname = FCDATA[FCCode]['FCName']
+        FCDATA.pop(FCCode)
+        save_carrier_data(FCDATA)
+        await ctx.send(f'Carrier {fcname} ({FCCode}) has been removed from the list')
+
+
+@bot.command(name='rename_FC', help='Rename a Fleet Carrier alias. \n'
+                                    'FCCode: Carrier ID Code \n'
+                                    'FCName: new name for the Carrier ')
+@commands.has_any_role('Bot Handler')
+async def renameFC(ctx, FCCode, FCName):
+    FCCode = FCCode.upper()
+    FCName = FCName.lower()
+
+    matched = re.match("[a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9]-[a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9]", FCCode)
+    isnt_match = not bool(matched)  # If it is NOT a match, we enter the Invalid FC Code condition
+
+    if isnt_match:
+        await ctx.send(f'Invalid Fleet Carrier Code format! Format should look like XXX-YYY')
+        return
+    if FCCode in FCDATA.keys():
+        fcname_old = FCDATA[FCCode]['FCName']
+        FCDATA[FCCode]['FCName'] = FCName
+        save_carrier_data(FCDATA)
+        await ctx.send(f'Carrier {fcname_old} ({FCCode}) has been renamed to {FCName}')
+
+
 @bot.command(name='list', help='Lists all tracked carriers')
 async def fclist(ctx):
-    fcfile = open(".env")
-    envlist = fcfile.readlines()
-    fcfile.close()
-
-    names = envlist[4].lower()
-    names = names.strip('\n')
-    namelist = names.split('.')
-    namelist.remove('')
-    if not namelist:
-        namelist = ['No Fleet Carriers are being tracked, add one!']
+    names = []
+    for fc_code, fc_data in FCDATA.items():
+        names.append("%s (%s)" % ( fc_data['FCName'], fc_code))
+    if not names:
+        names = ['No Fleet Carriers are being tracked, add one!']
     print('Listing active carriers')
-    namelist = '\n'.join(namelist)  # Joining the list with newline as the delimeter
+
+    names = '\n'.join(names)  # Joining the list with newline as the delimeter
     embed = discord.Embed(title='Tracked carriers')
-    embed.add_field(name = 'Carrier Names', value = namelist)
+    embed.add_field(name = 'Carrier Names', value = names)
     print('Sent!')
 
     await ctx.send(embed=embed)
@@ -251,20 +263,52 @@ async def on_command_error(ctx, error):
     if isinstance(error, commands.errors.CheckFailure):
         await ctx.send('You do not have the correct role for this command.')
 
-
-def verify_config():
-    # if this is the first run with a fresh .env, format it the way we expect.
-    fcfile = open(".env")
+def convert_carrier_data():
+    print(f'Attempting to convert old style carrier list, searching for data:')
+    dotenv_file = find_dotenv()
+    fcfile = open(dotenv_file)
     envlist = fcfile.readlines()
     fcfile.close()
-    if len(envlist) < 6:
-        print(f'.env Fleet Carrier list is empty, making space.')
-        envlist += ['\n'] * (6 - len(envlist))
-        fcfile = open(".env", "w")
-        fcwrite = "".join(envlist)
-        fcfile.write(fcwrite)
-        fcfile.close()
+
+    envlist[3] = envlist[3].strip('\n')
+    fcids = envlist[3].split('.')
+
+    envlist[4] = envlist[4].strip('\n')
+    names = envlist[4].split('.')
+
+    envlist[5] = envlist[5].strip('\n')
+    fcmids = envlist[5].split('.')
+
+    i = 0
+    FCDATA = {}
+
+    for carrier in fcids:
+        if carrier:
+            print(f"Found Carrier %s Name %s Mid %s" % ( carrier, names[i], fcmids[i] ))
+            FCDATA[carrier.upper()] = {'FCName': names[i].lower(), 'FCMid': fcmids[i], 'FCSys': 'unknown'}
+        i = i + 1
+
+    save_carrier_data(FCDATA)
+    print(f'Please remove the old style carrier list from the .env file')
+    return FCDATA
 
 
-verify_config()
+def load_carrier_data(CARRIERS):
+    # unpack carrier data if we have it, or start fresh
+    print(f'Loading Carrier Data.')
+    try:
+        FCDATA = json.loads(CARRIERS)
+    except:
+        FCDATA = convert_carrier_data()
+    return FCDATA
+
+
+def save_carrier_data(FCDATA):
+    print(f'Saving Carrier Data.')
+    dotenv_file = find_dotenv()
+    CARRIERS = json.dumps(FCDATA)
+    set_key(dotenv_file, "FLEET_CARRIERS", CARRIERS)
+
+
+FCDATA = load_carrier_data(CARRIERS)
 bot.run(TOKEN)

--- a/bot.py
+++ b/bot.py
@@ -63,7 +63,7 @@ async def dingle(ctx):
                                  'FCName: The alias with which you want to refer to the carrier. Please use something '
                                  'simple like "orion" or "9oclock", as this is what you use to call the stock command!'
                                  '\n!!SYSTEMS WITH SPACES IN THE NAMES NEED TO BE "QUOTED LIKE THIS"!! ')
-@commands.has_any_role('Carrier Owner','Bot Handler')
+@commands.has_any_role('Bot Handler', 'Admin', 'Mod')
 async def addFC(ctx, FCCode, FCSys, FCName):
     # Checking if FC is already in the list, and if FC name is in correct format
     # Stops if FC is already in list, or if incorrect name format
@@ -195,7 +195,7 @@ async def stock(ctx, fcname):
 
 @bot.command(name='del_FC', help='Delete a fleet carrier from the tracking database.\n'
                                  'FCCode: Carrier ID Code')
-@commands.has_any_role('Bot Handler')
+@commands.has_any_role('Bot Handler', 'Admin', 'Mod')
 async def delFC(ctx, FCCode):
     FCCode = FCCode.upper()
     matched = re.match("[a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9]-[a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9]", FCCode)
@@ -214,7 +214,7 @@ async def delFC(ctx, FCCode):
 @bot.command(name='rename_FC', help='Rename a Fleet Carrier alias. \n'
                                     'FCCode: Carrier ID Code \n'
                                     'FCName: new name for the Carrier ')
-@commands.has_any_role('Bot Handler')
+@commands.has_any_role('Bot Handler', 'Admin', 'Mod')
 async def renameFC(ctx, FCCode, FCName):
     FCCode = FCCode.upper()
     FCName = FCName.lower()


### PR DESCRIPTION
* Move the Fleet Carrier list into a dict.
* Convert old style Fleet Carrier list into the new dict
* Convert dict to json and save back to the .env file in a new variable FLEET_CARRIERS
* Add commands del_FC and rename_FC to add and rename Fleet Carriers

This addresses #2 and should make managing the Fleet Carrier list easier going forward.

This PR depends on the existing PR #5 , although it removes the verify_config function.