### PR TITLE
ENV prod/dev mode and start_wmm_tracking ownerid improvement

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -41,6 +41,8 @@ bot = commands.Bot(command_prefix=';', intents=intents)
 
 if ENV != 'prod':
     # Debugging, used only in dev.
+    # Add a handler to discords internal logger.
+    # This writes all events to 'discord.log'
     import logging
     logger = logging.getLogger('discord')
     logger.setLevel(logging.DEBUG)

--- a/bot.py
+++ b/bot.py
@@ -84,6 +84,8 @@ async def wmm_stock(message, channel):
     wmm_stock = {}
     for fcid in wmm_carriers:
         carrier_has_stock = False
+        if FCDATA[fcid]['wmm'] not in wmm_stock:
+            wmm_stock[FCDATA[fcid]['wmm']] = []
         stn_data = get_fc_stock(fcid, 'inara')
         if not stn_data:
             print("Inara stock check for carrier '%s' failed, skipping." % FCDATA[fcid]['FCName'])
@@ -109,8 +111,6 @@ async def wmm_stock(message, channel):
                 continue
             if com['stock'] != 0:
                 carrier_has_stock = True
-                if FCDATA[fcid]['wmm'] not in wmm_stock:
-                    wmm_stock[FCDATA[fcid]['wmm']] = []
                 if int(com['stock'].replace(',', '')) < 1000:
                     #wmm_stock[FCDATA[fcid]['wmm']].append("%s x %s - %s - **%s** - Price: %s - LOW STOCK %s (As of %s)" % (
                     #    com['name'], com['stock'], FCDATA[fcid]['wmm'], stn_data['full_name'][:-10], com['buyPrice'], FCDATA[fcid]['owner'], market_updated )


### PR DESCRIPTION
-  introduces a new ENV variable in the .env file which defaults to 'prod' if not specified. If this is set to 'dev' then additional debugging is activated and low stock DMs are overridden and sent only to DEVOWNERID. Nothing needs to be changed in the .env file for production, this is purely for my local environment.

- Makes the 'owner' parameter of _start_wmm_tracking_ optional, if not provided it will now take the ID of the user who typed the command.